### PR TITLE
Adding better TZ settings for BST/CST

### DIFF
--- a/sd/test/yi-hack.cfg
+++ b/sd/test/yi-hack.cfg
@@ -23,11 +23,13 @@ GATEWAY=192.168.1.254
 #    -boff -yoff : yellow off 
 LED_WHEN_READY=-boff -bon
 
-### Timezone
-TIMEZONE=GMT-2
-
-### NTP server
+### UK Timezone settings
+TIMEZONE=BST-1
 NTP_SERVER=0.uk.pool.ntp.org
+
+### US Timezone settings
+#TIMEZONE=CST5
+#NTP_SERVER=0.us.pool.ntp.org
 
 ### Debug
 # Debug mode, keep it to 'no' unless you known what you do


### PR DESCRIPTION
TZ has to be set to a fixed pattern in order to correctly switch to local time in order to display the correct date and time inside the video stream.
(ZONE+Offset to UTC)
A example for the US CST zone has been added.