### PR TITLE
Add a config option to enable DHCP

### DIFF
--- a/sd/test/equip_test.sh
+++ b/sd/test/equip_test.sh
@@ -59,7 +59,6 @@ log() {
 }
 
 get_config() {
-    key=$1
     grep "^$1=" /home/hd1/test/yi-hack.cfg  | cut -d"=" -f2
 }
 

--- a/sd/test/equip_test.sh
+++ b/sd/test/equip_test.sh
@@ -262,6 +262,11 @@ log "Debug mode = $(get_config DEBUG)"
 ### Let ppl hear that we start connect wifi
 /home/rmm "/home/hd1/voice/connectting.g726" 1
 
+HOSTNAME="$(get_config HOSTNAME)"
+HOSTNAME="${HOSTNAME// /}" # strip all whitespace
+log "Setting hostname to ${HOSTNAME}"
+hostname "${HOSTNAME}"
+
 log "Check for wifi configuration file...*"
 log $(find /home -name "wpa_supplicant.conf")
 
@@ -272,7 +277,7 @@ log "Wifi configuration answer: $res"
 
 if [[ $(get_config DHCP) == "yes" ]] ; then
     log "Do network configuration (DHCP)"
-    udhcpc --interface=ra0
+    udhcpc --interface=ra0 --hostname="${HOSTNAME}" >> ${LOG_FILE}
     log "Done"
 else
     log "Do network configuration 1/2 (IP and Gateway)"

--- a/sd/test/equip_test.sh
+++ b/sd/test/equip_test.sh
@@ -60,7 +60,7 @@ log() {
 
 get_config() {
     key=$1
-    grep $1 /home/hd1/test/yi-hack.cfg  | cut -d"=" -f2
+    grep "^$1=" /home/hd1/test/yi-hack.cfg  | cut -d"=" -f2
 }
 
 

--- a/sd/test/equip_test.sh
+++ b/sd/test/equip_test.sh
@@ -271,20 +271,25 @@ res=$(/home/wpa_supplicant -B -i ra0 -c /home/wpa_supplicant.conf )
 log "Status for wifi configuration=$?  (0 is ok)"
 log "Wifi configuration answer: $res"
 
-log "Do network configuration 1/2 (ip and gateway)"
-#ifconfig ra0 192.168.1.121 netmask 255.255.255.0
-#route add default gw 192.168.1.254
-ifconfig ra0 $(get_config IP) netmask $(get_config NETMASK)
-route add default gw $(get_config GATEWAY)
-log "Done"
+if [[ $(get_config DHCP) == "yes" ]] ; then
+    log "Do network configuration (DHCP)"
+    udhcpc --background --interface=ra0
+    log "Done"
+else
+    log "Do network configuration 1/2 (IP and Gateway)"
+    #ifconfig ra0 192.168.1.121 netmask 255.255.255.0
+    #route add default gw 192.168.1.254
+    ifconfig ra0 $(get_config IP) netmask $(get_config NETMASK)
+    route add default gw $(get_config GATEWAY)
+    log "Done"
+    ### configure DNS (google one)
+    log "Do network configuration 2/2 (DNS)"
+    echo "nameserver $(get_config NAMESERVER)" > /etc/resolv.conf
+    log "Done"
+fi
 
 log "Configuration is :"
 ifconfig | sed "s/^/    /" >> ${LOG_FILE}
-
-### configure DNS (google one)
-log "Do network configuration 2/2 (DNS)"
-echo "nameserver $(get_config NAMESERVER)" > /etc/resolv.conf
-log "Done"
 
 ### configure time on a NTP server
 log "Get time from a NTP server..."

--- a/sd/test/equip_test.sh
+++ b/sd/test/equip_test.sh
@@ -303,7 +303,8 @@ log "New datetime is $(date)"
 
 
 ### Check if reach gateway and notify
-ping -c1 -W2 $(get_config GATEWAY) > /dev/null
+GATEWAY=$(ip route | awk '/default/ { print $3 }')
+ping -c1 -W2 $GATEWAY > /dev/null
 if [ 0 -eq $? ]; then
     /home/rmm "/home/hd1/voice/wifi_connected.g726" 1
 fi
@@ -402,7 +403,8 @@ fi
 ### Final led color
 
 ### Check if reach gateway and notify
-ping -c1 -W2 $(get_config GATEWAY) > /dev/null
+GATEWAY=$(ip route | awk '/default/ { print $3 }')
+ping -c1 -W2 $GATEWAY > /dev/null
 if [ 0 -eq $? ]; then
     led $(get_config LED_WHEN_READY)
     /home/rmm "/home/hd1/voice/success.g726" 1

--- a/sd/test/equip_test.sh
+++ b/sd/test/equip_test.sh
@@ -272,7 +272,7 @@ log "Wifi configuration answer: $res"
 
 if [[ $(get_config DHCP) == "yes" ]] ; then
     log "Do network configuration (DHCP)"
-    udhcpc --background --interface=ra0
+    udhcpc --interface=ra0
     log "Done"
 else
     log "Do network configuration 1/2 (IP and Gateway)"

--- a/sd/test/yi-hack.cfg
+++ b/sd/test/yi-hack.cfg
@@ -3,6 +3,8 @@ ROOT_PASSWORD=1234qwer
 
 ### Network configuration
 # Don't forget to also fill the file wpa_supplicant.conf for the wifi configuration
+# Set DHCP to 'yes' to enable DHCP client (if 'yes', Yi will ignore IP/Netmask/etc settings below)
+DHCP=no
 IP=192.168.1.121
 NETMASK=255.255.255.0
 GATEWAY=192.168.1.254

--- a/sd/test/yi-hack.cfg
+++ b/sd/test/yi-hack.cfg
@@ -3,6 +3,8 @@ ROOT_PASSWORD=1234qwer
 
 ### Network configuration
 # Don't forget to also fill the file wpa_supplicant.conf for the wifi configuration
+# Hostname (cannot have any spaces)
+HOSTNAME=YiCamera
 # Set DHCP to 'yes' to enable DHCP client (if 'yes', Yi will ignore IP/Netmask/etc settings below)
 DHCP=no
 IP=192.168.1.121


### PR DESCRIPTION
This allows the Yi to use DCHP instead of a static IP, if `DHCP=yes` is specified in `yi-hack.cfg`. Thanks to @buckshee in #65.

I had to make the `get_config()` function stricter, because it was searching anywhere in the file (including comments, config values, etc). Now it only greps from the beginning of a line to `=` (i.e. only actual config keys).

Also, since the gateway check was reading `GATEWAY` from the config file (which may not be accurate when using DHCP), I changed it to read the gateway set in the system. If the user is using DHCP, this will return the DHCP-provided gateway address; if the user is using static IP assignment, this will return the gateway configured during network setup (i.e. `GATEWAY` from the config file).