### PR TITLE
Fix path to voice files

### DIFF
--- a/sd/test/equip_test.sh
+++ b/sd/test/equip_test.sh
@@ -41,7 +41,6 @@ led() {
     kill $(ps | grep led_ctl | grep -v grep | awk '{print $1}')
     # then process
     /home/led_ctl $@ &
-
 }
 
 LOG_DIR=/home/hd1/test/
@@ -63,7 +62,12 @@ get_config() {
     grep $1 /home/hd1/test/yi-hack.cfg  | cut -d"=" -f2
 }
 
-
+boot_voice() {
+    voice_file=$1
+    if [ "$(get_config BOOT_VOICE)" = "yes" ]; then
+        /home/rmm "$voice_file" 1
+    fi
+}
 
 ### first we assume that this script is started from /home/init.sh and will replace it from the below lines (which are not commented in init.sh :
 
@@ -114,8 +118,8 @@ cd /home/3518
 himm 0x20050074 0x06802424
 
 ### Let ppl hear that we start
-/home/rmm "/home/hd1/test/voice/welcome.g726" 1
-/home/rmm "/home/hd1/test/voice/wait.g726" 1
+boot_voice "/home/hd1/test/voice/welcome.g726"
+boot_voice "/home/hd1/test/voice/wait.g726"
 
 ### start blinking blue led for configuration in progress
 #/home/led_ctl -boff -yon &
@@ -261,7 +265,7 @@ log "Debug mode = $(get_config DEBUG)"
 # first, configure wifi
 
 ### Let ppl hear that we start connect wifi
-/home/rmm "/home/hd1/test/voice/connectting.g726" 1
+boot_voice "/home/hd1/test/voice/connectting.g726"
 
 log "Check for wifi configuration file...*"
 log $(find /home -name "wpa_supplicant.conf")
@@ -300,7 +304,7 @@ log "New datetime is $(date)"
 ### Check if reach gateway and notify
 ping -c1 -W2 $(get_config GATEWAY) > /dev/null
 if [ 0 -eq $? ]; then
-    /home/rmm "/home/hd1/test/voice/wifi_connected.g726" 1
+    boot_voice "/home/hd1/test/voice/wifi_connected.g726"
 fi
 
 ### set the root password
@@ -400,7 +404,7 @@ fi
 ping -c1 -W2 $(get_config GATEWAY) > /dev/null
 if [ 0 -eq $? ]; then
     led $(get_config LED_WHEN_READY)
-    /home/rmm "/home/hd1/test/voice/success.g726" 1
+    boot_voice "/home/hd1/test/voice/success.g726"
 else
     led -boff -yfast
 fi

--- a/sd/test/equip_test.sh
+++ b/sd/test/equip_test.sh
@@ -114,8 +114,8 @@ cd /home/3518
 himm 0x20050074 0x06802424
 
 ### Let ppl hear that we start
-/home/rmm "/home/hd1/voice/welcome.g726" 1
-/home/rmm "/home/hd1/voice/wait.g726" 1
+/home/rmm "/home/hd1/test/voice/welcome.g726" 1
+/home/rmm "/home/hd1/test/voice/wait.g726" 1
 
 ### start blinking blue led for configuration in progress
 #/home/led_ctl -boff -yon &
@@ -261,7 +261,7 @@ log "Debug mode = $(get_config DEBUG)"
 # first, configure wifi
 
 ### Let ppl hear that we start connect wifi
-/home/rmm "/home/hd1/voice/connectting.g726" 1
+/home/rmm "/home/hd1/test/voice/connectting.g726" 1
 
 log "Check for wifi configuration file...*"
 log $(find /home -name "wpa_supplicant.conf")
@@ -300,7 +300,7 @@ log "New datetime is $(date)"
 ### Check if reach gateway and notify
 ping -c1 -W2 $(get_config GATEWAY) > /dev/null
 if [ 0 -eq $? ]; then
-    /home/rmm "/home/hd1/voice/wifi_connected.g726" 1
+    /home/rmm "/home/hd1/test/voice/wifi_connected.g726" 1
 fi
 
 ### set the root password
@@ -400,7 +400,7 @@ fi
 ping -c1 -W2 $(get_config GATEWAY) > /dev/null
 if [ 0 -eq $? ]; then
     led $(get_config LED_WHEN_READY)
-    /home/rmm "/home/hd1/voice/success.g726" 1
+    /home/rmm "/home/hd1/test/voice/success.g726" 1
 else
     led -boff -yfast
 fi

--- a/sd/test/yi-hack.cfg
+++ b/sd/test/yi-hack.cfg
@@ -35,6 +35,11 @@ TIMEZONE=GMT0BST,M3.5.0/1,M10.5.0
 #If you want to change your ntp server you can see a list here http://www.pool.ntp.org/zone/@
 NTP_SERVER=0.uk.pool.ntp.org
 
+### Boot voice
+# If you want to disable the voice feedback during boot, change BOOT_VOICE to 'no'
+# Values : yes|no
+BOOT_VOICE=yes
+
 ### Debug
 # Debug mode, keep it to 'no' unless you known what you do
 # Values : yes|no


### PR DESCRIPTION
The voice file paths are missing `test/`; this PR fixes them so you can optionally hear status updates during boot. To disable, set `BOOT_VOICE=no` in `yi-hack.cfg`.

This is similar to #90, but fixes all affected voice paths in `equip_test.sh`.