### PR TITLE
Disabling eth0 (removes 192.168.1.128 IP)

### DIFF
--- a/sd/test/equip_test.sh
+++ b/sd/test/equip_test.sh
@@ -263,6 +263,14 @@ log "Debug mode = $(get_config DEBUG)"
 ### Let ppl hear that we start connect wifi
 /home/rmm "/home/hd1/voice/connectting.g726" 1
 
+# Regardless of network configuration, the Yi also listens on 192.168.1.128 using eth0
+# this can cause problems on the network if another device has that IP
+# `ifconfig eth0 down` doesn't seem to do anything except hide eth0 from `ifconfig` output
+# so manually remove the configured IP by setting it to 0.0.0.0
+log "Disabling eth0"
+ifconfig eth0 0.0.0.0
+ifconfig eth0 down
+
 log "Check for wifi configuration file...*"
 log $(find /home -name "wpa_supplicant.conf")
 


### PR DESCRIPTION
For some reason, the Yi configures itself to have a static IP of `192.168.1.128` _in addition to_ however you have configured it. This removes that secondary IP, preventing network collisions and reducing sketchiness.