### PR TITLE
Improve check_motion script

### DIFF
--- a/sd/test/check_motion.sh
+++ b/sd/test/check_motion.sh
@@ -1,12 +1,25 @@
 #!/bin/sh
-# each minute, check for a new video file (which is created in case of motion detection)
-# and if found, create the appropriate file for the http server
+# Every 20 seconds, check for files modified since we last checked
+# if there is activity, it means motion was recently detected
+# Since file writes begin immediately on motion detected, and don't end until approx 1min after motion ends, we only need to look for files modified very recently
+# Relies on running mp4record process
 
 cd /home/hd1/record/
-while [ 1 -eq 1 ] 
-  do
-    motion_file=$(find . -type f -name "*.mp4" -mmin -1 | tail -1)
-    echo "M="$motion_file
-    echo $motion_file | sed "s/.\//record\//" > /home/hd1/test/http/motion
-    sleep 30
+touch last_motion_check
+sleep 5 # since we /just/ created last_motion_check, the first check can return a false negative unless we wait a beat
+while true; do
+	echo "Checking for motion at `date`..."
+	has_motion=$([ -z "`find . -type f -name "*.mp4*" -newer last_motion_check`" ] && echo "false" || echo "true")
+	echo `date +%s` > last_motion_check
+	if [ -n "$1" ]; then
+		armed=$(ps | grep mp4record | grep -v grep -q && echo "true" || echo "false")
+		notification="{\"armed\": $armed, \"motion\": $has_motion, \"last_motion_check\": `cat last_motion_check`, \"host\": \"`hostname`\"}"
+		echo "$notification"
+		/home/curl -H "Content-Type: application/json" --data "$notification" "$1" --silent --show-error --stderr - && echo "$1 notified"
+	fi
+
+	motion_file=$(find . -type f -name "*.mp4" -mmin -1 | tail -1)
+	echo "Motion file: $motion_file"
+	echo $motion_file | sed "s/.\//record\//" > /home/hd1/test/http/motion
+	sleep 20
 done

--- a/sd/test/equip_test.sh
+++ b/sd/test/equip_test.sh
@@ -362,6 +362,9 @@ cd /home
 ./record_event &
 ./mp4record 60 &
 
+### Start motion detection & reporting
+log "Starting motion notification processes"
+/home/hd1/test/check_motion.sh $(get_config MOTION_NOTIFICATION_URL) > /${LOG_DIR}/log_motion.txt 2>&1 &
 
 ### Some configuration
 

--- a/sd/test/yi-hack.cfg
+++ b/sd/test/yi-hack.cfg
@@ -8,6 +8,11 @@ NETMASK=255.255.255.0
 GATEWAY=192.168.1.254
 NAMESERVER=192.168.1.254
 
+### Motion notifications
+# Optionally POST a JSON message of the status of motion detection to a URL
+# Values : URL to POST notification to, or leave empty to disable
+MOTION_NOTIFICATION_URL=
+
 ### Led color after full boot
 # The sequence will be : 
 # - orange : startup


### PR DESCRIPTION
This improves the check_motion script in several ways:

* Uses `-newer` flag to limit modification check to files modified since last check, and includes `.mp4.tmp` files in `find` call to increase accuracy
* Supports POSTing a JSON message to notify a local/internet server about motion status. Along with a device handler I'm working on, this will make the Yi into a motion sensor for SmartThings. Payload example:
    ```
    {
        "armed": true,
        "motion": false,
        "last_motion_check": 1490776393,
        "host": "YiCamera"
    }
    ```
* JSON message includes `armed` property, which tells whether or not the process that check_motion relies on is running (if it's not running, check_motion will always return `false` for motion). This limitation exists in the current version of check_motion, but is not documented.